### PR TITLE
Fix possible problems with https detection

### DIFF
--- a/internal/protocol/get/tls.go
+++ b/internal/protocol/get/tls.go
@@ -2,18 +2,14 @@ package get
 
 import (
 	"bytes"
+	"time"
+
 	"github.com/zhzyker/dismap/internal/proxy"
 	"github.com/zhzyker/dismap/pkg/logger"
-	"time"
 )
 
 func TlsProtocol(host string, port int, timeout int) ([]byte, error) {
 	conn, err := proxy.ConnProxyTls(host, port, timeout)
-	if logger.DebugError(err) {
-		return nil, err
-	}
-	msg := "GET /test HTTP/1.1\r\n\r\n"
-	_, err = conn.Write([]byte(msg))
 	if logger.DebugError(err) {
 		return nil, err
 	}
@@ -28,11 +24,12 @@ func TlsProtocol(host string, port int, timeout int) ([]byte, error) {
 		return reply, nil
 
 	}
-	conn, err = proxy.ConnProxyTcp(host, port, timeout)
+
+	conn, err = proxy.ConnProxyTls(host, port, timeout)
 	if logger.DebugError(err) {
 		return nil, err
 	}
-	msg = "GET /test HTTP/1.1\r\n\r\n"
+	msg := "GET /test HTTP/1.1\r\n\r\n"
 	_, err = conn.Write([]byte(msg))
 	if logger.DebugError(err) {
 		return nil, err


### PR DESCRIPTION
此方法总共建立两次连接，第一次看服务器是否主动发送数据，如果服务器不发送，则本地主动发送数据。
上次发现HTTPs无法探测提交了一次PR，由于代码理解问题，错误的将第一次连接修改为了本地主动发送，虽然HTTPs可以探测，但是可能存在其他服务无法检测的情况，这次PR修复了该问题，找到了实际问题点：第二次请求应该使用`proxy.ConnProxyTls`而不是`proxy.ConnProxyTcp`